### PR TITLE
Fix array to span and cbegin() to begin()

### DIFF
--- a/apps/printmap/printmap.vcxproj
+++ b/apps/printmap/printmap.vcxproj
@@ -26,7 +26,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{4a7c06b5-33d2-4951-83c4-ac1c01116786}</ProjectGuid>
     <RootNamespace>printmap</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/apps/printmap/src/main.cpp
+++ b/apps/printmap/src/main.cpp
@@ -89,10 +89,10 @@ static constexpr std::array<wl::JackNode,7> jack_nodes = {
 	/*j007*/wl::JackNode{}
 };
 
-static constexpr std::array<wl::InvestigatorNode,0> investigator_nodes = {
-};
+
 
 int main(int argc, char** argv) {
+	constexpr std::span<const wl::InvestigatorNode, 0> investigator_nodes;
 	const wl::MapGraph map_graph{map_nodes, jack_nodes, investigator_nodes};
 	std::cout << "Hello Rigel!" << std::endl;
 	print_graph(map_graph);

--- a/include/wl/wl.h
+++ b/include/wl/wl.h
@@ -23,7 +23,7 @@ private:
 	std::span<const ID> neighbors_{};
 
 	constexpr auto find_neighbor(ID nbor) const noexcept {
-		return std::find(neighbors_.cbegin(), neighbors_.cend(), nbor);
+		return std::find(neighbors_.begin(), neighbors_.end(), nbor);
 	}
 
 public:
@@ -33,14 +33,14 @@ public:
 
 	constexpr std::optional<ID> neighbor_counter_clockwise_of(ID nbor) const noexcept {
 		auto nbor_itr = find_neighbor(nbor);
-		if (nbor_itr == neighbors_.cend()) {
+		if (nbor_itr == neighbors_.end()) {
 			return std::nullopt;
 		}
 		// now decrement by one, since neighbors are in clockwise order
-		if (nbor_itr == neighbors_.cbegin()) {
+		if (nbor_itr == neighbors_.begin()) {
 			// note that we are guaranteed at least size() >= 1, since
 			// we found a the neighbour. Return last neighbour in list.
-			nbor_itr = (neighbors_.cend() - 1);
+			nbor_itr = (neighbors_.end() - 1);
 		} else {
 			--nbor_itr;
 		}
@@ -49,14 +49,14 @@ public:
 
 	constexpr std::optional<ID> neighbor_clockwise_of(ID nbor) const noexcept {
 		auto nbor_itr = find_neighbor(nbor);
-		if (nbor_itr == neighbors_.cend()) {
+		if (nbor_itr == neighbors_.end()) {
 			return std::nullopt;
 		}
 		// now increment by one, since neighbors are in clockwise order
 		++nbor_itr;
-		if (nbor_itr == neighbors_.cend()) {
+		if (nbor_itr == neighbors_.end()) {
 			// wrap around to beginning
-			nbor_itr = neighbors_.cbegin();
+			nbor_itr = neighbors_.begin();
 		}
 		return *nbor_itr;
 	}


### PR DESCRIPTION
Changed the array of investigatornode array to a span (windows doesnt
like empty arrays). replaced all instances of cbegin and cend with being
and end.