### PR TITLE
Add nodes in 320s-360s

### DIFF
--- a/include/wl/default_map.h
+++ b/include/wl/default_map.h
@@ -339,7 +339,17 @@ static constexpr std::array<MapNode,MapGraph::num_nodes_total> map_nodes = {
 	/*i326*/MapNode{i326_nbors},
 	/*i327*/MapNode{i327_nbors},
 	/*i328*/MapNode{i328_nbors},
-	/*i329*/MapNode{i329_nbors}
+	/*i329*/MapNode{i329_nbors},
+	/*i330*/MapNode{i330_nbors}, // 330s
+	/*i331*/MapNode{i331_nbors},
+	/*i332*/MapNode{i332_nbors},
+	/*i333*/MapNode{i333_nbors},
+	/*i334*/MapNode{i334_nbors},
+	/*i335*/MapNode{i335_nbors},
+	/*i336*/MapNode{i336_nbors},
+	/*i337*/MapNode{i337_nbors},
+	/*i338*/MapNode{i338_nbors},
+	/*i339*/MapNode{i339_nbors}
 };
 
 static constexpr std::array<JackNode,JackNode::num_nodes_total> jack_nodes = {
@@ -666,7 +676,7 @@ static constexpr std::array<InvestigatorNode, InvestigatorNode::num_nodes_total>
 	/*i317*/InvestigatorNode{},
 	/*i318*/InvestigatorNode{},
 	/*i319*/InvestigatorNode{},
-	/*i320*/InvestigatorNode{},  // 320s
+	/*i320*/InvestigatorNode{}, // 320s
 	/*i321*/InvestigatorNode{},
 	/*i322*/InvestigatorNode{},
 	/*i323*/InvestigatorNode{},
@@ -675,7 +685,17 @@ static constexpr std::array<InvestigatorNode, InvestigatorNode::num_nodes_total>
 	/*i326*/InvestigatorNode{},
 	/*i327*/InvestigatorNode{},
 	/*i328*/InvestigatorNode{},
-	/*i329*/InvestigatorNode{}
+	/*i329*/InvestigatorNode{},
+	/*i330*/InvestigatorNode{}, // 330s
+	/*i331*/InvestigatorNode{},
+	/*i332*/InvestigatorNode{},
+	/*i333*/InvestigatorNode{},
+	/*i334*/InvestigatorNode{},
+	/*i335*/InvestigatorNode{},
+	/*i336*/InvestigatorNode{},
+	/*i337*/InvestigatorNode{},
+	/*i338*/InvestigatorNode{},
+	/*i339*/InvestigatorNode{}
 };
 
 constexpr MapGraph default_map() noexcept {

--- a/include/wl/default_map.h
+++ b/include/wl/default_map.h
@@ -359,7 +359,20 @@ static constexpr std::array<MapNode,MapGraph::num_nodes_total> map_nodes = {
 	/*i346*/MapNode{i346_nbors},
 	/*i347*/MapNode{i347_nbors},
 	/*i348*/MapNode{i348_nbors},
-	/*i349*/MapNode{i349_nbors}
+	/*i349*/MapNode{i349_nbors},
+	/*i350*/MapNode{i350_nbors}, // 350s
+	/*i351*/MapNode{i351_nbors},
+	/*i352*/MapNode{i352_nbors},
+	/*i353*/MapNode{i353_nbors},
+	/*i354*/MapNode{i354_nbors},
+	/*i355*/MapNode{i355_nbors},
+	/*i356*/MapNode{i356_nbors},
+	/*i357*/MapNode{i357_nbors},
+	/*i358*/MapNode{i358_nbors},
+	/*i359*/MapNode{i359_nbors},
+	/*i360*/MapNode{i360_nbors}, // 360s
+	/*i361*/MapNode{i361_nbors},
+	/*i362*/MapNode{i362_nbors}
 };
 
 static constexpr std::array<JackNode,JackNode::num_nodes_total> jack_nodes = {
@@ -715,7 +728,20 @@ static constexpr std::array<InvestigatorNode, InvestigatorNode::num_nodes_total>
 	/*i346*/InvestigatorNode{},
 	/*i347*/InvestigatorNode{},
 	/*i348*/InvestigatorNode{},
-	/*i349*/InvestigatorNode{}
+	/*i349*/InvestigatorNode{},
+	/*i350*/InvestigatorNode{}, // 350s
+	/*i351*/InvestigatorNode{},
+	/*i352*/InvestigatorNode{},
+	/*i353*/InvestigatorNode{},
+	/*i354*/InvestigatorNode{},
+	/*i355*/InvestigatorNode{},
+	/*i356*/InvestigatorNode{},
+	/*i357*/InvestigatorNode{},
+	/*i358*/InvestigatorNode{},
+	/*i359*/InvestigatorNode{},
+	/*i360*/InvestigatorNode{}, // 360s
+	/*i361*/InvestigatorNode{},
+	/*i362*/InvestigatorNode{}
 };
 
 constexpr MapGraph default_map() noexcept {

--- a/include/wl/default_map.h
+++ b/include/wl/default_map.h
@@ -330,7 +330,16 @@ static constexpr std::array<MapNode,MapGraph::num_nodes_total> map_nodes = {
 	/*i317*/MapNode{i317_nbors},
 	/*i318*/MapNode{i318_nbors},
 	/*i319*/MapNode{i319_nbors},
-	/*i320*/MapNode{i320_nbors}  // 320s
+	/*i320*/MapNode{i320_nbors}, // 320s
+	/*i321*/MapNode{i321_nbors},
+	/*i322*/MapNode{i322_nbors},
+	/*i323*/MapNode{i323_nbors},
+	/*i324*/MapNode{i324_nbors},
+	/*i325*/MapNode{i325_nbors},
+	/*i326*/MapNode{i326_nbors},
+	/*i327*/MapNode{i327_nbors},
+	/*i328*/MapNode{i328_nbors},
+	/*i329*/MapNode{i329_nbors}
 };
 
 static constexpr std::array<JackNode,JackNode::num_nodes_total> jack_nodes = {
@@ -657,8 +666,16 @@ static constexpr std::array<InvestigatorNode, InvestigatorNode::num_nodes_total>
 	/*i317*/InvestigatorNode{},
 	/*i318*/InvestigatorNode{},
 	/*i319*/InvestigatorNode{},
-	/*i320*/InvestigatorNode{}  // 320s
-
+	/*i320*/InvestigatorNode{},  // 320s
+	/*i321*/InvestigatorNode{},
+	/*i322*/InvestigatorNode{},
+	/*i323*/InvestigatorNode{},
+	/*i324*/InvestigatorNode{},
+	/*i325*/InvestigatorNode{},
+	/*i326*/InvestigatorNode{},
+	/*i327*/InvestigatorNode{},
+	/*i328*/InvestigatorNode{},
+	/*i329*/InvestigatorNode{}
 };
 
 constexpr MapGraph default_map() noexcept {

--- a/include/wl/default_map.h
+++ b/include/wl/default_map.h
@@ -349,7 +349,17 @@ static constexpr std::array<MapNode,MapGraph::num_nodes_total> map_nodes = {
 	/*i336*/MapNode{i336_nbors},
 	/*i337*/MapNode{i337_nbors},
 	/*i338*/MapNode{i338_nbors},
-	/*i339*/MapNode{i339_nbors}
+	/*i339*/MapNode{i339_nbors},
+	/*i340*/MapNode{i340_nbors}, // 340s
+	/*i341*/MapNode{i341_nbors},
+	/*i342*/MapNode{i342_nbors},
+	/*i343*/MapNode{i343_nbors},
+	/*i344*/MapNode{i344_nbors},
+	/*i345*/MapNode{i345_nbors},
+	/*i346*/MapNode{i346_nbors},
+	/*i347*/MapNode{i347_nbors},
+	/*i348*/MapNode{i348_nbors},
+	/*i349*/MapNode{i349_nbors}
 };
 
 static constexpr std::array<JackNode,JackNode::num_nodes_total> jack_nodes = {
@@ -695,7 +705,17 @@ static constexpr std::array<InvestigatorNode, InvestigatorNode::num_nodes_total>
 	/*i336*/InvestigatorNode{},
 	/*i337*/InvestigatorNode{},
 	/*i338*/InvestigatorNode{},
-	/*i339*/InvestigatorNode{}
+	/*i339*/InvestigatorNode{},
+	/*i340*/InvestigatorNode{}, // 340s
+	/*i341*/InvestigatorNode{},
+	/*i342*/InvestigatorNode{},
+	/*i343*/InvestigatorNode{},
+	/*i344*/InvestigatorNode{},
+	/*i345*/InvestigatorNode{},
+	/*i346*/InvestigatorNode{},
+	/*i347*/InvestigatorNode{},
+	/*i348*/InvestigatorNode{},
+	/*i349*/InvestigatorNode{}
 };
 
 constexpr MapGraph default_map() noexcept {

--- a/include/wl/i_nodes.h
+++ b/include/wl/i_nodes.h
@@ -429,6 +429,36 @@ static constexpr std::array<MapNode::Adjacency, 4> i328_nbors = {
 static constexpr std::array<MapNode::Adjacency, 4> i329_nbors = {
 	map_id(157u), map_id(159u), map_id(175u), map_id(328u) };
 
+static constexpr std::array<MapNode::Adjacency, 3> i330_nbors = {
+	map_id(159u), map_id(331u), map_id(177u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i331_nbors = {
+	map_id(160u), map_id(177u), map_id(330u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i332_nbors = {
+	map_id(161u), map_id(163u), map_id(178u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i333_nbors = {
+	map_id(163u), map_id(164u), map_id(181u), map_id(180u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i334_nbors = {
+	map_id(165u), map_id(184u), map_id(183u), map_id(181u) };
+
+static constexpr std::array<MapNode::Adjacency, 2> i335_nbors = {
+	map_id(0u), map_id(173u) };
+
+static constexpr std::array<MapNode::Adjacency, 2> i336_nbors = {
+	map_id(173u), map_id(175u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i337_nbors = {
+	map_id(0u), map_id(175u), map_id(176u) };
+
+static constexpr std::array<MapNode::Adjacency, 2> i338_nbors = {
+	map_id(175u), map_id(177u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i339_nbors = {
+	map_id(161u), map_id(340u), map_id(176u), map_id(177u) };
+
 } // namespace wl
 
 #endif // WL_I_NODES_H

--- a/include/wl/i_nodes.h
+++ b/include/wl/i_nodes.h
@@ -489,6 +489,45 @@ static constexpr std::array<MapNode::Adjacency, 4> i348_nbors = {
 static constexpr std::array<MapNode::Adjacency, 4> i349_nbors = {
 	map_id(113u), map_id(350u), map_id(115u), map_id(114u) };
 
+static constexpr std::array<MapNode::Adjacency, 3> i350_nbors = {
+	map_id(96u), map_id(351u), map_id(349u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i351_nbors = {
+	map_id(97u), map_id(98u), map_id(116u), map_id(350u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i352_nbors = {
+	map_id(115u), map_id(116u), map_id(133u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i353_nbors = {
+	map_id(132u), map_id(133u), map_id(149u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i354_nbors = {
+	map_id(147u), map_id(149u), map_id(150u), map_id(148u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i355_nbors = {
+	map_id(146u), map_id(148u), map_id(356u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i356_nbors = {
+	map_id(169u), map_id(355u), map_id(170u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i357_nbors = {
+	map_id(169u), map_id(359u), map_id(187u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i358_nbors = {
+	map_id(187u), map_id(188u), map_id(343u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i359_nbors = {
+	map_id(171u), map_id(188u), map_id(357u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i360_nbors = {
+	map_id(170u), map_id(172u), map_id(171u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i361_nbors = {
+	map_id(150u), map_id(151u), map_id(172u) };
+
+static constexpr std::array<MapNode::Adjacency, 2> i362_nbors = {
+	map_id(133u), map_id(151u) };
+
 } // namespace wl
 
 #endif // WL_I_NODES_H

--- a/include/wl/i_nodes.h
+++ b/include/wl/i_nodes.h
@@ -459,6 +459,36 @@ static constexpr std::array<MapNode::Adjacency, 2> i338_nbors = {
 static constexpr std::array<MapNode::Adjacency, 4> i339_nbors = {
 	map_id(161u), map_id(340u), map_id(176u), map_id(177u) };
 
+static constexpr std::array<MapNode::Adjacency, 3> i340_nbors = {
+	map_id(178u), map_id(179u), map_id(339u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i341_nbors = {
+	map_id(179u), map_id(180u), map_id(182u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i342_nbors = {
+	map_id(182u), map_id(183u), map_id(185u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i343_nbors = {
+	map_id(185u), map_id(186u), map_id(358u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i344_nbors = {
+	map_id(167u), map_id(168u), map_id(186u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i345_nbors = {
+	map_id(144u), map_id(145u), map_id(146u), map_id(168u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i346_nbors = {
+	map_id(145u), map_id(347u), map_id(147u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i347_nbors = {
+	map_id(131u), map_id(348u), map_id(346u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i348_nbors = {
+	map_id(112u), map_id(114u), map_id(132u), map_id(347u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i349_nbors = {
+	map_id(113u), map_id(350u), map_id(115u), map_id(114u) };
+
 } // namespace wl
 
 #endif // WL_I_NODES_H

--- a/include/wl/i_nodes.h
+++ b/include/wl/i_nodes.h
@@ -402,6 +402,33 @@ static constexpr std::array<MapNode::Adjacency, 3> i319_nbors = {
 static constexpr std::array<MapNode::Adjacency, 3> i320_nbors = {
 	map_id(137u), map_id(139u), map_id(138u) };
 
+static constexpr std::array<MapNode::Adjacency, 2> i321_nbors = {
+	map_id(139u), map_id(160u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i322_nbors = {
+	map_id(161u), map_id(313u), map_id(162u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i323_nbors = {
+	map_id(141u), map_id(164u), map_id(162u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i324_nbors = {
+	map_id(152u), map_id(154u), {map_id(327u), MapNode::Adjacency::WaterBorder{}} };
+
+static constexpr std::array<MapNode::Adjacency, 4> i325_nbors = {
+	map_id(155u), map_id(156u), map_id(328u), map_id(154u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i326_nbors = {
+	map_id(136u), map_id(158u), map_id(156u) };
+
+static constexpr std::array<MapNode::Adjacency, 3> i327_nbors = {
+	map_id(173u), {map_id(324u), MapNode::Adjacency::WaterBorder{}}, map_id(174u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i328_nbors = {
+	map_id(174u), map_id(325u), map_id(329u), map_id(175u) };
+
+static constexpr std::array<MapNode::Adjacency, 4> i329_nbors = {
+	map_id(157u), map_id(159u), map_id(175u), map_id(328u) };
+
 } // namespace wl
 
 #endif // WL_I_NODES_H

--- a/include/wl/j_nodes.h
+++ b/include/wl/j_nodes.h
@@ -483,7 +483,7 @@ static constexpr std::array<MapNode::Adjacency, 1> j157_nbors = {
 	map_id(329u) };
 
 static constexpr std::array<MapNode::Adjacency, 1> j158_nbors = {
-	map_id(329u) };
+	map_id(326u) };
 
 static constexpr std::array<MapNode::Adjacency, 2> j159_nbors = {
 	map_id(329u), map_id(330u) };

--- a/include/wl/wl.h
+++ b/include/wl/wl.h
@@ -133,7 +133,7 @@ public:
 
 class InvestigatorNode {
 public:
-	static constexpr std::size_t num_nodes_total = 151u; // so far
+	static constexpr std::size_t num_nodes_total = 161u; // so far
 
 private:
 	bool starting_position_ = false;

--- a/include/wl/wl.h
+++ b/include/wl/wl.h
@@ -133,7 +133,7 @@ public:
 
 class InvestigatorNode {
 public:
-	static constexpr std::size_t num_nodes_total = 141u; // so far
+	static constexpr std::size_t num_nodes_total = 151u; // so far
 
 private:
 	bool starting_position_ = false;

--- a/include/wl/wl.h
+++ b/include/wl/wl.h
@@ -133,7 +133,7 @@ public:
 
 class InvestigatorNode {
 public:
-	static constexpr std::size_t num_nodes_total = 161u; // so far
+	static constexpr std::size_t num_nodes_total = 174u; // so far
 
 private:
 	bool starting_position_ = false;

--- a/include/wl/wl.h
+++ b/include/wl/wl.h
@@ -24,7 +24,7 @@ public:
 	public:
 		struct WaterBorder{};
 
-		constexpr Adjacency(ID neighbor_id) noexcept
+		constexpr Adjacency(ID neighbor_id)
 			: id_{neighbor_id}
 			, is_water_{ false }
 		{}
@@ -133,7 +133,7 @@ public:
 
 class InvestigatorNode {
 public:
-	static constexpr std::size_t num_nodes_total = 132u; // so far
+	static constexpr std::size_t num_nodes_total = 141u; // so far
 
 private:
 	bool starting_position_ = false;

--- a/test/node_blocks_iterator_test.cpp
+++ b/test/node_blocks_iterator_test.cpp
@@ -39,7 +39,7 @@ TEST(ClockwiseNodeBlocks, all_blocks_for_node_9) {
 	{
 		const wl::ClockwiseBlock first_block = *itr;
 		EXPECT_FALSE(first_block.is_water_block());
-		constexpr std::array<wl::MapNode::Adjacency, 4> expected_adjacencies = {
+		constexpr std::array<wl::MapNode::ID, 4> expected_adjacencies = {
 			wl::map_id(9u), wl::map_id(189u), wl::map_id(1u), wl::map_id(190u)
 		};
 		EXPECT_TRUE(std::equal(
@@ -52,7 +52,7 @@ TEST(ClockwiseNodeBlocks, all_blocks_for_node_9) {
 	{
 		const wl::ClockwiseBlock second_block = *itr;
 		EXPECT_FALSE(second_block.is_water_block());
-		constexpr std::array<wl::MapNode::Adjacency, 7> expected_adjacencies = {
+		constexpr std::array<wl::MapNode::ID, 7> expected_adjacencies = {
 			wl::map_id(9u),  wl::map_id(190u), wl::map_id(11u), wl::map_id(208u),
 			wl::map_id(10u), wl::map_id(207u), wl::map_id(189u)
 		};
@@ -84,7 +84,7 @@ TEST(JackNodeBlocks, all_blocks_for_node_9) {
 	{
 		const wl::JackNodesBlock first_block = *itr;
 		EXPECT_FALSE(first_block.is_water_block());
-		constexpr std::array<wl::MapNode::Adjacency, 2> expected_adjacencies = {
+		constexpr std::array<wl::MapNode::ID, 2> expected_adjacencies = {
 			wl::map_id(9u), wl::map_id(1u)
 		};
 		EXPECT_TRUE(std::equal(
@@ -97,7 +97,7 @@ TEST(JackNodeBlocks, all_blocks_for_node_9) {
 	{
 		const wl::JackNodesBlock second_block = *itr;
 		EXPECT_FALSE(second_block.is_water_block());
-		constexpr std::array<wl::MapNode::Adjacency, 3> expected_adjacencies = {
+		constexpr std::array<wl::MapNode::ID, 3> expected_adjacencies = {
 			wl::map_id(9u), wl::map_id(11u), wl::map_id(10u)
 		};
 		EXPECT_TRUE(std::equal(


### PR DESCRIPTION
Fixes #3 

Also fixes an issue that where:
 - Visual Studio compiler compares `wl::Adjacency` against a `wl::MapNode::ID` successfully by instantiating an `wl::Adjacency` from the `wl::MapNode::ID` *(successfully but unintentionally)*
 - Clang compiler refuses to compare those two different types
 
So in 67f089c I change the *expected values* arrays to the proper type.