### PR TITLE
new Jack moves .h file and jack moves unit tests

### DIFF
--- a/include/wl/j_moves.h
+++ b/include/wl/j_moves.h
@@ -1,0 +1,34 @@
+#ifndef WL_J_MOVES_H
+#define WL_J_MOVES_H
+
+#include <cstdint>
+#include <cassert>
+#include <array>
+#include <optional>
+#include <wl/wl.h>
+#include <wl/jack_inventory.h>
+
+namespace wl {
+
+class JackMove {
+	MapNode::ID where_to_;
+	std::optional<JackResource> resource_;
+
+public:
+	constexpr JackMove(MapNode::ID whereto) noexcept
+		: where_to_{ whereto }
+		, resource_{ std::nullopt }
+	{}
+	constexpr JackMove(MapNode::ID whereto, JackResource move_cost) noexcept
+		: where_to_{ whereto }
+		, resource_{ move_cost }
+	{}
+
+	constexpr MapNode::ID destination() const noexcept { return where_to_; }
+	constexpr std::optional<JackResource> cost() const noexcept { return resource_; }
+};
+
+} // namespace
+
+#endif
+

--- a/test/jack_move_test.cpp
+++ b/test/jack_move_test.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include <wl/j_moves.h>
+
+TEST(JackMove, no_cost) {
+	const wl::JackMove move{ wl::map_id(2) };
+
+	const auto cost = move.cost();
+	EXPECT_EQ(cost, std::nullopt);
+}
+
+TEST(JackMove, accurate_cost) {
+	const wl::JackMove move{ wl::map_id(2), wl::JackResource::CARRIAGE };
+
+	const auto cost = move.cost();
+	ASSERT_TRUE(cost.has_value());
+	EXPECT_EQ(cost, wl::JackResource::CARRIAGE);
+}
+
+TEST(JackMove, accurate_destination) {
+	const wl::JackMove move{ wl::map_id(2) };
+	const wl::JackMove move_with_cost{ wl::map_id(3), wl::JackResource::CARRIAGE };
+
+	const auto destination = move.destination();
+	const auto destination_with_cost = move_with_cost.destination();
+	EXPECT_EQ(destination, wl::map_id(2) );
+	EXPECT_EQ(destination_with_cost, wl::map_id(3));
+}

--- a/test/unit_test.vcxproj
+++ b/test/unit_test.vcxproj
@@ -167,6 +167,7 @@
   <ItemGroup>
     <ClCompile Include="block_iterator_test.cpp" />
     <ClCompile Include="i_node_test.cpp" />
+    <ClCompile Include="jack_move_test.cpp" />
     <ClCompile Include="node_blocks_iterator_test.cpp" />
     <ClCompile Include="normal_node_test.cpp" />
     <ClCompile Include="no_evidence_node_test.cpp" />

--- a/test/unit_test.vcxproj.filters
+++ b/test/unit_test.vcxproj.filters
@@ -45,5 +45,8 @@
     <ClCompile Include="player_locations_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="jack_move_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
What are the "test/unit_test.vcxproj" and "test/unit_test.vcxproj.filters" changes for exactly? I think it has something to do with having new Jack Move tests run in the solution build. Or am I confused?

Thanks,
Rigel