### PR TITLE
Find normal j moves

### DIFF
--- a/include/wl/discovery_locations.h
+++ b/include/wl/discovery_locations.h
@@ -15,9 +15,9 @@ public:
 	using iterator = std::array<MapNode::ID,4>::const_iterator;
 
 	constexpr DiscoveryLocations(MapNode::ID loc0,
-		                         MapNode::ID loc1,
-		                         MapNode::ID loc2,
-		                         MapNode::ID loc3) noexcept
+								 MapNode::ID loc1,
+								 MapNode::ID loc2,
+								 MapNode::ID loc3) noexcept
 		: locations_{loc0, loc1, loc2, loc3}
 	{}
 

--- a/include/wl/discovery_locations.h
+++ b/include/wl/discovery_locations.h
@@ -15,9 +15,9 @@ public:
 	using iterator = std::array<MapNode::ID,4>::const_iterator;
 
 	constexpr DiscoveryLocations(MapNode::ID loc0,
-								 MapNode::ID loc1,
-								 MapNode::ID loc2,
-								 MapNode::ID loc3) noexcept
+	                             MapNode::ID loc1,
+	                             MapNode::ID loc2,
+	                             MapNode::ID loc3) noexcept
 		: locations_{loc0, loc1, loc2, loc3}
 	{}
 

--- a/include/wl/discovery_locations.h
+++ b/include/wl/discovery_locations.h
@@ -1,0 +1,31 @@
+#ifndef WL_DISCOVERY_LOCATIONS_H
+#define WL_DISCOVERY_LOCATIONS_H
+
+#include <cstdint>
+#include <cassert>
+#include <array>
+#include <wl/wl.h>
+
+namespace wl {
+
+class DiscoveryLocations {
+	std::array<MapNode::ID,4> locations_;
+
+public:
+	using iterator = std::array<MapNode::ID,4>::const_iterator;
+
+	constexpr DiscoveryLocations(MapNode::ID loc0,
+		                         MapNode::ID loc1,
+		                         MapNode::ID loc2,
+		                         MapNode::ID loc3) noexcept
+		: locations_{loc0, loc1, loc2, loc3}
+	{}
+
+	constexpr iterator begin() const noexcept { return locations_.begin(); }
+	constexpr iterator end() const noexcept { return locations_.end(); }
+	constexpr auto size() const noexcept { return locations_.size(); }
+};
+
+} // namespace
+
+#endif

--- a/include/wl/find_j_moves.h
+++ b/include/wl/find_j_moves.h
@@ -1,0 +1,127 @@
+#ifndef WL_FIND_J_MOVES_H
+#define WL_FIND_J_MOVES_H
+
+#include <vector>
+#include <wl/wl.h>
+#include <wl/game_state.h>
+#include <wl/j_moves.h>
+
+namespace wl {
+
+inline std::vector<JackMove> available_normal_jack_moves(const GameState& game_state,
+	                                                     const History& game_history,
+	                                                     const MapGraph& map_graph) {
+	const MapNode::ID current_jack_position = game_state.jack_location();
+
+	struct ExplorationFrame {
+		MapNode::ID node_id;
+		std::span<const MapNode::Adjacency> remaining_adjacencies;
+	};
+
+	std::vector<MapNode::ID> visited_nodes;
+	std::vector<ExplorationFrame> exploration_stack;
+
+	const auto have_visited = [&visited_nodes] (MapNode::ID id) -> bool {
+		const auto end = visited_nodes.cend();
+		return std::find(visited_nodes.cbegin(), end, id) != end;
+	};
+
+	// prime the exploration stack with Jack's current position
+	exploration_stack.emplace_back(ExplorationFrame{
+		current_jack_position,
+		map_graph.map_node(current_jack_position).neighbors()});
+	visited_nodes.push_back(current_jack_position);
+
+	std::vector<JackMove> results;
+	while (!exploration_stack.empty()) {
+		ExplorationFrame& frame = exploration_stack.back();
+
+		// if we are done exploring this node, then go back to where we were before
+		if (frame.remaining_adjacencies.empty()) {
+			exploration_stack.pop_back();
+			continue;
+		}
+
+		// get the current adjacency
+		const MapNode::Adjacency adjacency =
+			frame.remaining_adjacencies.back();
+		// and remove it from the list of remaining adjacencies
+		frame.remaining_adjacencies =
+			frame.remaining_adjacencies.first(
+				frame.remaining_adjacencies.size() - 1);
+
+		// check if we've been here before, or if this is a non-traversable
+		// water adjacency
+		if (adjacency.is_water_border() || have_visited(adjacency.id())) {
+			continue;
+		}
+		// otherwise add it to the list of places we've been
+		visited_nodes.emplace_back(adjacency.id());
+
+		// now we know we are visiting a new node
+		if (map_graph.is_jack_node(adjacency.id())) {
+			// this is a Jack node, so it is a valid normal move location
+			results.push_back(JackMove{adjacency.id()});
+			continue;
+		}
+
+		// we are visiting an Investigator node
+		if (game_state.has_investigator_at_location(adjacency.id())) {
+			continue;
+		}
+
+		// otherwise explore this node (ie. add a stack frame for this node)
+		exploration_stack.emplace_back(ExplorationFrame{
+			adjacency.id(),
+		    map_graph.map_node(adjacency.id()).neighbors()});
+	}
+	return results;
+}
+
+inline std::vector<JackMove> available_carriage_jack_moves(const GameState& game_state,
+	                                                       const History& game_history,
+	                                                       const MapGraph& map_graph) {
+	// iterate over all adjacent jack nodes, and all adjacenct jack nodes to
+	// *that* node.
+	// Ensure that final destination nodes are not a discovery location.
+	// TODO: really implement
+	return std::vector<JackMove>{};
+}
+
+inline std::vector<JackMove> available_alley_jack_moves(const GameState& game_state,
+	                                                    const History& game_history,
+	                                                    const MapGraph& map_graph) {
+	// TODO: really implement
+	return std::vector<JackMove>{};
+}
+
+inline std::vector<JackMove> available_boat_jack_moves(const GameState& game_state,
+	                                                   const History& game_history,
+	                                                   const MapGraph& map_graph) {
+	// TODO: really implement
+	return std::vector<JackMove>{};
+}
+
+// Returns the set of possible jack moves given the game state
+inline std::vector<JackMove> available_jack_moves(const GameState& game_state,
+	                                              const History& game_history,
+	                                              const MapGraph& map_graph) {
+	std::vector<JackMove> moves = available_normal_jack_moves(game_state, game_history, map_graph);
+	const auto carriage_moves = available_carriage_jack_moves(game_state, game_history, map_graph);
+	const auto alley_moves = available_alley_jack_moves(game_state, game_history, map_graph);
+	const auto boat_moves = available_boat_jack_moves(game_state, game_history, map_graph);
+
+	moves.reserve(moves.size() +
+		          carriage_moves.size() +
+		          alley_moves.size() +
+		          boat_moves.size());
+	auto moves_back_inserter = std::back_inserter(moves);
+	std::copy(carriage_moves.begin(), carriage_moves.end(), moves_back_inserter);
+	std::copy(alley_moves.begin(), alley_moves.end(), moves_back_inserter);
+	std::copy(boat_moves.begin(), boat_moves.end(), moves_back_inserter);
+	return moves;
+}
+
+} // namespace wl
+
+#endif

--- a/include/wl/game_state.h
+++ b/include/wl/game_state.h
@@ -1,0 +1,44 @@
+#ifndef WL_GAME_STATE_H
+#define WL_GAME_STATE_H
+
+#include <wl/wl.h>
+#include <wl/discovery_locations.h>
+#include <wl/player_locations.h>
+#include <wl/investigator_abilities.h>
+#include <wl/j_moves.h>
+
+namespace wl {
+
+struct History{}; // TODO
+
+class GameState {
+	PlayerLocations       player_locations_;
+	DiscoveryLocations    discovery_locations_;
+	InvestigatorAbilities investigator_abilities_;
+	JackInventory         jack_inventory_;
+
+public:
+	constexpr GameState(PlayerLocations starting_locations,
+		                DiscoveryLocations discovery_locations,
+		                InvestigatorAbilities starting_abilities,
+		                JackInventory starting_jack_inventory) noexcept
+		: player_locations_{std::move(starting_locations)}
+		, discovery_locations_{std::move(discovery_locations)}
+		, investigator_abilities_{std::move(starting_abilities)}
+		, jack_inventory_{std::move(starting_jack_inventory)}
+	{}
+
+	// note: accounts for "double-moves" when using a carriage
+	std::uint8_t moves_made_by_jack_since_last_discovery() const;
+
+	bool has_investigator_at_location(MapNode::ID node_id) const noexcept {
+		return player_locations_.has_investigator_at_location(node_id);
+	}
+	MapNode::ID jack_location() const noexcept {
+	 	return player_locations_.jack_location();
+	}
+};
+
+} // namespace
+
+#endif

--- a/include/wl/j_moves.h
+++ b/include/wl/j_moves.h
@@ -26,6 +26,20 @@ public:
 
 	constexpr MapNode::ID destination() const noexcept { return where_to_; }
 	constexpr std::optional<JackResource> cost() const noexcept { return resource_; }
+
+	constexpr bool operator==(const JackMove& other) const noexcept {
+		return (where_to_ == other.where_to_) &&
+		       (resource_ == other.resource_);
+	}
+	constexpr bool operator!=(const JackMove& other) const noexcept {
+		return !(*this == other);
+	}
+
+	constexpr bool operator<(const JackMove& other) const noexcept {
+		return (where_to_ < other.where_to_) ||
+			   (   (where_to_ == other.where_to_) &&
+			       (resource_ < other.resource_));
+	}
 };
 
 } // namespace

--- a/include/wl/player_locations.h
+++ b/include/wl/player_locations.h
@@ -34,6 +34,12 @@ public:
 	}
 	constexpr MapNode::ID jack_location() const noexcept { return jack_location_; }
 
+	bool has_investigator_at_location(MapNode::ID node_id) const noexcept {
+		return (node_id == investigator_location(InvestigatorID::ZERO))
+		    || (node_id == investigator_location(InvestigatorID::ONE))
+		    || (node_id == investigator_location(InvestigatorID::TWO));
+	}
+
 	void move_investigator(InvestigatorID id, MapNode::ID to_location) noexcept {
 		switch (id) {
 		case InvestigatorID::ZERO: std::get<0>(investigator_locations_) = to_location; break;

--- a/test/find_j_moves_test.cpp
+++ b/test/find_j_moves_test.cpp
@@ -1,0 +1,166 @@
+#include <map>
+#include <algorithm>
+#include <initializer_list>
+#include <gtest/gtest.h>
+#include <wl/game_state.h>
+#include <wl/find_j_moves.h>
+#include <wl/default_map.h>
+
+namespace wl {
+std::ostream& operator<<(std::ostream& os, JackResource resource) {
+	switch (resource) {
+	case JackResource::CARRIAGE: os << "CARRIAGE"; break;
+	case JackResource::ALLEY: os << "ALLEY"; break;
+	case JackResource::BOAT: os << "BOAT"; break;
+	}
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os, JackMove move) {
+	os << "JackMove{destination:" << static_cast<size_t>(move.destination());
+	if (const auto cost = move.cost(); cost.has_value()) {
+		os << ",cost:" << *cost;
+	}
+	os << "}";
+	return os;
+}
+} // namespace wl
+
+namespace {
+const wl::MapGraph k_default_map = wl::default_map();
+
+
+void do_normal_moves_test(std::initializer_list<wl::JackMove> expected_moves,
+	                      const wl::GameState& game_state,
+	                      const wl::History& history)
+{
+	// setup a map to keep track of which expected moves we found
+	std::map<wl::JackMove, bool> expected_moves_found;
+	for (const wl::JackMove expected_move : expected_moves) {
+		expected_moves_found.emplace(expected_move, false);
+	}
+	ASSERT_EQ(expected_moves_found.size(), expected_moves.size());
+
+	// find the moves
+	const auto found_moves = available_normal_jack_moves(game_state, history, k_default_map);
+	EXPECT_EQ(expected_moves_found.size(), found_moves.size());
+
+	// check that all moves found were expected
+	for (const wl::JackMove move : found_moves) {
+		auto itr = expected_moves_found.find(move);
+		if (itr == expected_moves_found.end()) {
+			FAIL() << "found unexpected move: " << move;
+			continue;
+		}
+		// note that we found this move
+		itr->second = true;
+	}
+
+	// check that all expected moves were found
+	for (const auto& keyval : expected_moves_found) {
+		if (!keyval.second) {
+			FAIL() << "did not find expected move: " << keyval.first;
+		}
+	}
+}
+
+} // namespace
+
+TEST(FindJackMoves, simple_normal_moves) {
+	// Make a game state. Not trying to involve investigators, so put them all in a corner.
+	// Don't give Jack any cards.
+	constexpr wl::MapNode::ID jack_location = wl::map_id(66);
+	constexpr wl::PlayerLocations player_locations{wl::map_id(189), wl::map_id(190), wl::map_id(191), jack_location};
+	const wl::GameState game_state{
+		player_locations,
+		wl::DiscoveryLocations{wl::map_id(173), wl::map_id(11), wl::map_id(64), wl::map_id(132)},
+		wl::InvestigatorAbilities{},
+		wl::JackInventory{0,0,0} // no jack cards
+	};
+	const wl::History history{};
+
+	// Here, Jack only has two options, each from the same stem i node (232).
+	//
+	//   *              *
+	// (j64)--(i232)--(j67)
+	//          |
+	//        (j66) <- jack is here
+	do_normal_moves_test(
+		{
+			wl::JackMove{wl::map_id(64)},
+			wl::JackMove{wl::map_id(67)}
+		},
+		game_state,
+		history);
+}
+
+TEST(FindJackMoves, normal_moves_through_multiple_i_nodes) {
+	// Make a game state. Not trying to involve investigators, so put them all in a corner.
+	// Don't give Jack any cards.
+	constexpr wl::MapNode::ID jack_location = wl::map_id(8);
+	constexpr wl::PlayerLocations player_locations{wl::map_id(202), wl::map_id(203), wl::map_id(204), jack_location};
+	const wl::GameState game_state{
+		player_locations,
+		wl::DiscoveryLocations{wl::map_id(173), wl::map_id(11), wl::map_id(64), wl::map_id(132)},
+		wl::InvestigatorAbilities{},
+		wl::JackInventory{0,0,0} // no jack cards
+	};
+	const wl::History history{};
+
+	// Here we test that Jack is able to reach nodes through more than one i node,
+	// namely via the routes of either j008->i189->i207->somewhere or j008->i206->i207->somewhere
+	//
+	// jack    (j001)*
+	//   V        |
+	// (j008)--(i189)--(j009)*
+	//    |       |
+	// (i206)--(i207)--(j010)* 
+	//    |       |
+	// (j028)  (j029)
+	//    *       *
+	do_normal_moves_test(
+		{
+			wl::JackMove{wl::map_id(1)},
+			wl::JackMove{wl::map_id(9)},
+			wl::JackMove{wl::map_id(10)},
+			wl::JackMove{wl::map_id(29)},
+			wl::JackMove{wl::map_id(28)}
+		},
+		game_state,
+		history);
+}
+
+TEST(FindJackMoves, normal_moves_stopped_by_investigator) {
+	// Make a game state. Put an investigator on node i189 to block Jack
+	// Don't give Jack any cards.
+	constexpr wl::MapNode::ID jack_location = wl::map_id(8);
+	constexpr wl::PlayerLocations player_locations{wl::map_id(189), wl::map_id(203), wl::map_id(204), jack_location};
+	const wl::GameState game_state{
+		player_locations,
+		wl::DiscoveryLocations{wl::map_id(173), wl::map_id(11), wl::map_id(64), wl::map_id(132)},
+		wl::InvestigatorAbilities{},
+		wl::JackInventory{0,0,0} // no jack cards
+	};
+	const wl::History history{};
+
+	// Here we test that Jack is able to reach nodes through more than one i node,
+	// even if an investigator is blocking one of his routes to that node.
+	// Namely he shall go via the route of either j008->i206->i207->somewhere
+	//
+	// jack    (j001) ,- investigator here
+	//   V        |  /
+	// (j008)-x(i189)--(j009)
+	//    |       X
+	// (i206)--(i207)--(j010)* 
+	//    |       |
+	// (j028)  (j029)
+	//    *       *
+	do_normal_moves_test(
+		{
+			wl::JackMove{wl::map_id(10)},
+			wl::JackMove{wl::map_id(29)},
+			wl::JackMove{wl::map_id(28)}
+		},
+		game_state,
+		history);
+}

--- a/test/unit_test.vcxproj
+++ b/test/unit_test.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="jack_inventory_test.cpp" />
     <ClCompile Include="player_locations_test.cpp" />
     <ClCompile Include="investigator_abilities_test.cpp" />
+    <ClCompile Include="find_j_moves_test.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/test/unit_test.vcxproj.filters
+++ b/test/unit_test.vcxproj.filters
@@ -51,5 +51,8 @@
     <ClCompile Include="investigator_abilities_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="find_j_moves_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
So there are quite a few things left unfinished here:
 - DiscoveryLocations is untested and unvalidated
 - History is an empty structure with no implementation
 - Card-based J moves are not yet implemented, and are just dummy functions for now

However, I think we get to a good-enough interim state here by at least implementing a simple search for available normal moves.