### PR TITLE
Implement alley and boat moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ whitehall
 x64/
 Win32/
 .vs/
+wl_test
+

--- a/include/wl/block_iterator.h
+++ b/include/wl/block_iterator.h
@@ -70,6 +70,7 @@ public:
 
 	ClockwiseBlockIterator& operator++() {
 		as_begin_ = false;
+
 		const auto& node = map_graph_->map_node(current_node_id_);
 		if (node.neighbors().size() == 1u) {
 			// double-back on spikes like:
@@ -84,12 +85,12 @@ public:
 			//           |              *: current node
 			//         ( 3 )
 			//
-			// skipping re-visit of node 2
-			const auto& last_node = map_graph_->map_node(last_node_id_);
-			const auto next_adjacency = last_node.neighbor_clockwise_of(current_node_id_);
-			assert(next_adjacency.has_value());
-			current_node_id_ = next_adjacency->id();
-			return *this;
+			// go back to base-of-spike node
+			const MapNode::ID tmp = last_node_id_;
+			last_node_id_ = current_node_id_;
+			current_node_id_ = tmp;
+			// and call increment again so that we don't have anyone call operator*() at this node again
+			return ++(*this);
 		}
 		const auto next_adjacency = node.neighbor_counter_clockwise_of(last_node_id_);
 		last_node_id_ = current_node_id_;

--- a/include/wl/find_j_moves.h
+++ b/include/wl/find_j_moves.h
@@ -186,8 +186,12 @@ inline std::vector<JackMove> available_alley_jack_moves(const GameState& game_st
 inline std::vector<JackMove> available_boat_jack_moves(const GameState& game_state,
 	                                                   const History& game_history,
 	                                                   const MapGraph& map_graph) {
-	// TODO: really implement
-	return std::vector<JackMove>{};
+	const auto blocks = JackNodeBlocks{game_state.jack_location(), map_graph};
+	std::vector<JackMove> moves;
+	blocks.for_each_water_neighbor([&moves](MapNode::ID water_neighbor){
+		moves.push_back(JackMove{ water_neighbor, JackResource::BOAT });
+	});
+	return moves;
 }
 
 // Returns the set of possible jack moves given the game state

--- a/include/wl/find_j_moves.h
+++ b/include/wl/find_j_moves.h
@@ -5,6 +5,7 @@
 #include <wl/wl.h>
 #include <wl/game_state.h>
 #include <wl/j_moves.h>
+#include <wl/j_node_blocks_iterator.h>
 
 namespace wl {
 
@@ -174,8 +175,12 @@ inline std::vector<JackMove> available_carriage_jack_moves(const GameState& game
 inline std::vector<JackMove> available_alley_jack_moves(const GameState& game_state,
 	                                                    const History& game_history,
 	                                                    const MapGraph& map_graph) {
-	// TODO: really implement
-	return std::vector<JackMove>{};
+	const auto blocks = JackNodeBlocks{game_state.jack_location(), map_graph};
+	std::vector<JackMove> moves;
+	blocks.for_each_alley_neighbor([&moves](MapNode::ID alley_neighbor){
+		moves.push_back(JackMove{ alley_neighbor, JackResource::ALLEY });
+	});
+	return moves;
 }
 
 inline std::vector<JackMove> available_boat_jack_moves(const GameState& game_state,

--- a/include/wl/j_node_blocks_iterator.h
+++ b/include/wl/j_node_blocks_iterator.h
@@ -135,6 +135,7 @@ public:
 			if (block_itr == block_end) {
 				continue;
 			}
+			assert(block_itr.get_graph().jack_node(*block_itr).is_water());
 			++block_itr;
 
 			for (; block_itr != block_end; ++block_itr) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ GTEST_LIB_DIR=../../googletest-release-1.11.0/build/lib
 CC=clang++
 CXXFLAGS=-std=c++20 -I../include -isystem$(GTEST_INC_DIR)
 LDFLAGS=-L$(GTEST_LIB_DIR) -lgtest
-DEPS=block_iterator.h default_map.h discovery_locations.h find_j_moves.h game_state.h i_nodes.h investigator_abilities.h investigator_id.h j_moves.h j_node_block_iterator.h j_node_blocks_iterator.h j_nodes.h jack_inventory.h node_blocks_iterator.h player_locations.h tagged_id.h wl.h
+DEPS=../include/wl/block_iterator.h ../include/wl/default_map.h ../include/wl/discovery_locations.h ../include/wl/find_j_moves.h ../include/wl/game_state.h ../include/wl/i_nodes.h ../include/wl/investigator_abilities.h ../include/wl/investigator_id.h ../include/wl/j_moves.h ../include/wl/j_node_block_iterator.h ../include/wl/j_node_blocks_iterator.h ../include/wl/j_nodes.h ../include/wl/jack_inventory.h ../include/wl/node_blocks_iterator.h ../include/wl/player_locations.h ../include/wl/tagged_id.h ../include/wl/wl.h
 ODIR=obj
 OBJ = block_iterator_test.o find_j_moves_test.o i_node_test.o investigator_abilities_test.o jack_inventory_test.o jack_move_test.o map_node_test.o no_evidence_node_test.o node_blocks_iterator_test.o normal_node_test.o player_locations_test.o water_node_test.o
 
@@ -17,7 +17,7 @@ wl_test: $(OBJ) main.cpp
 test: wl_test
 	./wl_test
 
-.PHONY: clean
+.PHONY: clean test
 
 clean:
 	rm -f *.o wl_test

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,23 @@
+GTEST_INC_DIR=../../googletest-release-1.11.0/googletest/include
+GTEST_LIB_DIR=../../googletest-release-1.11.0/build/lib
+
+CC=clang++
+CXXFLAGS=-std=c++20 -I../include -isystem$(GTEST_INC_DIR)
+LDFLAGS=-L$(GTEST_LIB_DIR) -lgtest
+DEPS=block_iterator.h default_map.h discovery_locations.h find_j_moves.h game_state.h i_nodes.h investigator_abilities.h investigator_id.h j_moves.h j_node_block_iterator.h j_node_blocks_iterator.h j_nodes.h jack_inventory.h node_blocks_iterator.h player_locations.h tagged_id.h wl.h
+ODIR=obj
+OBJ = block_iterator_test.o find_j_moves_test.o i_node_test.o investigator_abilities_test.o jack_inventory_test.o jack_move_test.o map_node_test.o no_evidence_node_test.o node_blocks_iterator_test.o normal_node_test.o player_locations_test.o water_node_test.o
+
+%.o: %.c $(DEPS)
+	$(CC) -c -o $@ $< $(CXXFLAGS)
+
+wl_test: $(OBJ) main.cpp
+	$(CC) -o $@ $^ $(CXXFLAGS) $(LDFLAGS)
+
+test: wl_test
+	./wl_test
+
+.PHONY: clean
+
+clean:
+	rm -f *.o wl_test

--- a/test/find_j_moves_test.cpp
+++ b/test/find_j_moves_test.cpp
@@ -279,19 +279,19 @@ TEST(FindJackMoves, only_alley_moves) {
 	// adjacent to his current location, despite that fact that he is hemmed-in by investigators
 	// for all of his normal move locations. Investigators at * locations
 	//
-    //      |                             |
-    //   (i322)----------(j162)--------(i323)
-    //      |                             |
-    //      |         BLOCK   Jack     (j164)
-    //      |                  v          |
-    //   (j161)----(i332)*---(j163)----(i333)*-
-    //      |       |                     |
-    //           (j178)       BLOCK    (j180)
-    //              |                     |
-    //           (i340)-----(j179)-----(i341)--
-    //
-    // We expect that he should be able to reach each location prefixed with j and
-    // pictured in this map.
+	//      |                             |
+	//   (i322)----------(j162)--------(i323)
+	//      |                             |
+	//      |         BLOCK   Jack     (j164)
+	//      |                  v          |
+	//   (j161)----(i332)*---(j163)----(i333)*-
+	//      |       |                     |
+	//           (j178)       BLOCK    (j180)
+	//              |                     |
+	//           (i340)-----(j179)-----(i341)--
+	//
+	// We expect that he should be able to reach each location prefixed with j and
+	// pictured in this map.
 	do_alley_moves_test(
 		{
 			wl::JackMove{wl::map_id(161),wl::JackResource::ALLEY},
@@ -323,20 +323,20 @@ TEST(FindJackMoves, only_boat_moves) {
 	// adjacent to his current location, despite that fact that he is hemmed-in by investigators
 	// for all of his normal move locations. Investigators at * locations
 	//
-    //      \ /                                            |
-    //  --(i284)--(i285)--(j94)--(i275)*-(j79)--(i249)--(i250)--
-    //       |       |              |             |        |
-    //       |    (j111)W        (j95)W         (j80)W     |
-    //       |                                             |
-    //    (j112)               WATER BLOCK               (j97)
-    //       |                                             |
-    //       |  Jack is here --> (j113)W    (j96)W         |
-    //       |                      |          |           |
-    //  --(i348)------(j114)-----(i349)*----(i350)*-----(i351)--
-    //       |                                             |
-    //
-    // We expect that he should be able to reach each location prefixed with j and
-    // suffixed with W (for "water") pictured in this map.
+	//      \ /                                            |
+	//  --(i284)--(i285)--(j94)--(i275)*-(j79)--(i249)--(i250)--
+	//       |       |              |             |        |
+	//       |    (j111)W        (j95)W         (j80)W     |
+	//       |                                             |
+	//    (j112)               WATER BLOCK               (j97)
+	//       |                                             |
+	//       |  Jack is here --> (j113)W    (j96)W         |
+	//       |                      |          |           |
+	//  --(i348)------(j114)-----(i349)*----(i350)*-----(i351)--
+	//       |                                             |
+	//
+	// We expect that he should be able to reach each location prefixed with j and
+	// suffixed with W (for "water") pictured in this map.
 	do_boat_moves_test(
 		{
 			wl::JackMove{wl::map_id(80),wl::JackResource::BOAT},
@@ -370,24 +370,24 @@ TEST(FindJackMoves, boat_and_carriage_moves) {
 	//                                                                       --(J46)--
 	//                                                                           |
 	//                                                                        (i231)--(J65)--
-    //                            \ /                                            |
-    //                        --(i284)--(i285)--(j94)--(i275)*-(J79)--(i249)--(i250)--(J64)--
-    //                             |       |              |             |        |
-    //                             |    (j111)W        (j95)W         (J80)W     |
-    //                             |                                             |
-    //                          (J112)               WATER BLOCK               (J97)
-    //                             |                                             |
-    //                  (J131)W    |  Jack is here --> (j113)W    (J96)W         |
-    //                     |       |                      |          |           |
-    //--(J145)--(i346)--(i347)--(i348)------(J114)-----(i349)*----(i350)*-----(i351)--(J98)W
-    //             |               |                      |                      |
-    //          (J147)          (J132)                 (J115)                    |
-    //             |               |                      |                      |
-    //                                ------(J133)-----(i352)-----------------(J116)
-    //
-    // We expect that he should be able to reach each location prefixed with j and
-    // suffixed with W (for "water") pictured in this map, or any location with
-    // a capital J by carriage.
+	//                            \ /                                            |
+	//                        --(i284)--(i285)--(j94)--(i275)*-(J79)--(i249)--(i250)--(J64)--
+	//                             |       |              |             |        |
+	//                             |    (j111)W        (j95)W         (J80)W     |
+	//                             |                                             |
+	//                          (J112)               WATER BLOCK               (J97)
+	//                             |                                             |
+	//                  (J131)W    |  Jack is here --> (j113)W    (J96)W         |
+	//                     |       |                      |          |           |
+	//--(J145)--(i346)--(i347)--(i348)------(J114)-----(i349)*----(i350)*-----(i351)--(J98)W
+	//             |               |                      |                      |
+	//          (J147)          (J132)                 (J115)                    |
+	//             |               |                      |                      |
+	//                                ------(J133)-----(i352)-----------------(J116)
+	//
+	// We expect that he should be able to reach each location prefixed with j and
+	// suffixed with W (for "water") pictured in this map, or any location with
+	// a capital J by carriage.
 	do_all_moves_test(
 		{
 			wl::JackMove{wl::map_id(80),wl::JackResource::BOAT},

--- a/test/find_j_moves_test.cpp
+++ b/test/find_j_moves_test.cpp
@@ -29,10 +29,11 @@ std::ostream& operator<<(std::ostream& os, JackMove move) {
 namespace {
 const wl::MapGraph k_default_map = wl::default_map();
 
-
-void do_normal_moves_test(std::initializer_list<wl::JackMove> expected_moves,
-	                      const wl::GameState& game_state,
-	                      const wl::History& history)
+template <class FindMovesFunc>
+void do_moves_test(std::initializer_list<wl::JackMove> expected_moves,
+	               const wl::GameState& game_state,
+	               const wl::History& history,
+	               FindMovesFunc&& find_moves)
 {
 	// setup a map to keep track of which expected moves we found
 	std::map<wl::JackMove, bool> expected_moves_found;
@@ -42,7 +43,7 @@ void do_normal_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 	ASSERT_EQ(expected_moves_found.size(), expected_moves.size());
 
 	// find the moves
-	const auto found_moves = available_normal_jack_moves(game_state, history, k_default_map);
+	const auto found_moves = find_moves(game_state, history, k_default_map);
 	EXPECT_EQ(expected_moves_found.size(), found_moves.size());
 
 	// check that all moves found were expected
@@ -62,74 +63,37 @@ void do_normal_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 			FAIL() << "did not find expected move: " << keyval.first;
 		}
 	}
+}
+
+
+void do_normal_moves_test(std::initializer_list<wl::JackMove> expected_moves,
+	                      const wl::GameState& game_state,
+	                      const wl::History& history)
+{
+	do_moves_test(std::forward<std::initializer_list<wl::JackMove>>(expected_moves),
+		game_state,
+		history,
+		wl::available_normal_jack_moves);
 }
 
 void do_carriage_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 	const wl::GameState& game_state,
 	const wl::History& history)
 {
-	// setup a map to keep track of which expected moves we found
-	std::map<wl::JackMove, bool> expected_moves_found;
-	for (const wl::JackMove expected_move : expected_moves) {
-		expected_moves_found.emplace(expected_move, false);
-	}
-	ASSERT_EQ(expected_moves_found.size(), expected_moves.size());
-
-	// find the moves
-	const auto found_moves = available_carriage_jack_moves(game_state, history, k_default_map);
-	EXPECT_EQ(expected_moves_found.size(), found_moves.size());
-
-	// check that all moves found were expected
-	for (const wl::JackMove move : found_moves) {
-		auto itr = expected_moves_found.find(move);
-		if (itr == expected_moves_found.end()) {
-			FAIL() << "found unexpected move: " << move;
-			continue;
-		}
-		// note that we found this move
-		itr->second = true;
-	}
-
-	// check that all expected moves were found
-	for (const auto& keyval : expected_moves_found) {
-		if (!keyval.second) {
-			FAIL() << "did not find expected move: " << keyval.first;
-		}
-	}
+	do_moves_test(std::forward<std::initializer_list<wl::JackMove>>(expected_moves),
+		game_state,
+		history,
+		wl::available_carriage_jack_moves);
 }
 
 void do_alley_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 	const wl::GameState& game_state,
 	const wl::History& history)
 {
-	// setup a map to keep track of which expected moves we found
-	std::map<wl::JackMove, bool> expected_moves_found;
-	for (const wl::JackMove expected_move : expected_moves) {
-		expected_moves_found.emplace(expected_move, false);
-	}
-	ASSERT_EQ(expected_moves_found.size(), expected_moves.size());
-
-	// find the moves
-	const auto found_moves = available_alley_jack_moves(game_state, history, k_default_map);
-	EXPECT_EQ(expected_moves_found.size(), found_moves.size());
-
-	// check that all moves found were expected
-	for (const wl::JackMove move : found_moves) {
-		auto itr = expected_moves_found.find(move);
-		if (itr == expected_moves_found.end()) {
-			FAIL() << "found unexpected move: " << move;
-			continue;
-		}
-		// note that we found this move
-		itr->second = true;
-	}
-
-	// check that all expected moves were found
-	for (const auto& keyval : expected_moves_found) {
-		if (!keyval.second) {
-			FAIL() << "did not find expected move: " << keyval.first;
-		}
-	}
+	do_moves_test(std::forward<std::initializer_list<wl::JackMove>>(expected_moves),
+		game_state,
+		history,
+		wl::available_alley_jack_moves);
 }
 
 } // namespace

--- a/test/find_j_moves_test.cpp
+++ b/test/find_j_moves_test.cpp
@@ -106,6 +106,16 @@ void do_boat_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 		wl::available_boat_jack_moves);
 }
 
+void do_all_moves_test(std::initializer_list<wl::JackMove> expected_moves,
+	const wl::GameState& game_state,
+	const wl::History& history)
+{
+	do_moves_test(std::forward<std::initializer_list<wl::JackMove>>(expected_moves),
+		game_state,
+		history,
+		wl::available_jack_moves);
+}
+
 } // namespace
 
 TEST(FindJackMoves, simple_normal_moves) {
@@ -297,7 +307,7 @@ TEST(FindJackMoves, only_alley_moves) {
 
 TEST(FindJackMoves, only_boat_moves) {
 	// Make a game state.
-	// Give Jack 1 alley tile.
+	// Give Jack 1 boat tile.
 	// Add investigators blocking other moves
 	constexpr wl::MapNode::ID jack_location = wl::map_id(113);
 	constexpr wl::PlayerLocations player_locations{ wl::map_id(349), wl::map_id(350), wl::map_id(275), jack_location };
@@ -333,6 +343,74 @@ TEST(FindJackMoves, only_boat_moves) {
 			wl::JackMove{wl::map_id(95),wl::JackResource::BOAT},
 			wl::JackMove{wl::map_id(96),wl::JackResource::BOAT},
 			wl::JackMove{wl::map_id(111),wl::JackResource::BOAT}
+		},
+		game_state,
+		history);
+}
+
+TEST(FindJackMoves, boat_and_carriage_moves) {
+	// Make a game state.
+	// Give Jack 1 carriage tile and 1 boat tile.
+	// Add investigators blocking other moves
+	constexpr wl::MapNode::ID jack_location = wl::map_id(113);
+	constexpr wl::PlayerLocations player_locations{ wl::map_id(349), wl::map_id(350), wl::map_id(275), jack_location };
+	const wl::GameState game_state{
+		player_locations,
+		wl::DiscoveryLocations{wl::map_id(173), wl::map_id(11), wl::map_id(67), wl::map_id(171)},
+		wl::InvestigatorAbilities{},
+		wl::JackInventory{1,0,1} // 1 carriage and 1 boat card
+	};
+	const wl::History history{};
+
+	// Here we test that Jack is able to reach any other j-node in the same water block
+	// adjacent to his current location AND any j-node 1 or 2 hops away, despite the fact
+	// that he is hemmed-in by investigators for all of his normal move locations.
+	// Investigators at * locations
+	//                                                                           |      
+	//                                                                       --(J46)--
+	//                                                                           |
+	//                                                                        (i231)--(J65)--
+    //                            \ /                                            |
+    //                        --(i284)--(i285)--(j94)--(i275)*-(J79)--(i249)--(i250)--(J64)--
+    //                             |       |              |             |        |
+    //                             |    (j111)W        (j95)W         (J80)W     |
+    //                             |                                             |
+    //                          (J112)               WATER BLOCK               (J97)
+    //                             |                                             |
+    //                  (J131)W    |  Jack is here --> (j113)W    (J96)W         |
+    //                     |       |                      |          |           |
+    //--(J145)--(i346)--(i347)--(i348)------(J114)-----(i349)*----(i350)*-----(i351)--(J98)W
+    //             |               |                      |                      |
+    //          (J147)          (J132)                 (J115)                    |
+    //             |               |                      |                      |
+    //                                ------(J133)-----(i352)-----------------(J116)
+    //
+    // We expect that he should be able to reach each location prefixed with j and
+    // suffixed with W (for "water") pictured in this map, or any location with
+    // a capital J by carriage.
+	do_all_moves_test(
+		{
+			wl::JackMove{wl::map_id(80),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(95),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(96),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(111),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(46),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(64),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(65),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(79),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(80),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(96),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(97),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(98),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(112),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(114),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(115),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(116),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(131),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(132),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(133),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(145),wl::JackResource::CARRIAGE},
+			wl::JackMove{wl::map_id(147),wl::JackResource::CARRIAGE}
 		},
 		game_state,
 		history);

--- a/test/find_j_moves_test.cpp
+++ b/test/find_j_moves_test.cpp
@@ -96,6 +96,16 @@ void do_alley_moves_test(std::initializer_list<wl::JackMove> expected_moves,
 		wl::available_alley_jack_moves);
 }
 
+void do_boat_moves_test(std::initializer_list<wl::JackMove> expected_moves,
+	const wl::GameState& game_state,
+	const wl::History& history)
+{
+	do_moves_test(std::forward<std::initializer_list<wl::JackMove>>(expected_moves),
+		game_state,
+		history,
+		wl::available_boat_jack_moves);
+}
+
 } // namespace
 
 TEST(FindJackMoves, simple_normal_moves) {
@@ -257,7 +267,7 @@ TEST(FindJackMoves, only_alley_moves) {
 
 	// Here we test that Jack is able to reach any other j-node on each of the two blocks
 	// adjacent to his current location, despite that fact that he is hemmed-in by investigators
-	// for all of his normal move locations
+	// for all of his normal move locations. Investigators at * locations
 	//
     //      |                             |
     //   (i322)----------(j162)--------(i323)
@@ -280,6 +290,49 @@ TEST(FindJackMoves, only_alley_moves) {
 			wl::JackMove{wl::map_id(178),wl::JackResource::ALLEY},
 			wl::JackMove{wl::map_id(179),wl::JackResource::ALLEY},
 			wl::JackMove{wl::map_id(180),wl::JackResource::ALLEY}
+		},
+		game_state,
+		history);
+}
+
+TEST(FindJackMoves, only_boat_moves) {
+	// Make a game state.
+	// Give Jack 1 alley tile.
+	// Add investigators blocking other moves
+	constexpr wl::MapNode::ID jack_location = wl::map_id(113);
+	constexpr wl::PlayerLocations player_locations{ wl::map_id(349), wl::map_id(350), wl::map_id(275), jack_location };
+	const wl::GameState game_state{
+		player_locations,
+		wl::DiscoveryLocations{wl::map_id(173), wl::map_id(11), wl::map_id(64), wl::map_id(132)},
+		wl::InvestigatorAbilities{},
+		wl::JackInventory{0,0,1} // 1 boat card
+	};
+	const wl::History history{};
+
+	// Here we test that Jack is able to reach any other j-node in the same water block
+	// adjacent to his current location, despite that fact that he is hemmed-in by investigators
+	// for all of his normal move locations. Investigators at * locations
+	//
+    //      \ /                                            |
+    //  --(i284)--(i285)--(j94)--(i275)*-(j79)--(i249)--(i250)--
+    //       |       |              |             |        |
+    //       |    (j111)W        (j95)W         (j80)W     |
+    //       |                                             |
+    //    (j112)               WATER BLOCK               (j97)
+    //       |                                             |
+    //       |  Jack is here --> (j113)W    (j96)W         |
+    //       |                      |          |           |
+    //  --(i348)------(j114)-----(i349)*----(i350)*-----(i351)--
+    //       |                                             |
+    //
+    // We expect that he should be able to reach each location prefixed with j and
+    // suffixed with W (for "water") pictured in this map.
+	do_boat_moves_test(
+		{
+			wl::JackMove{wl::map_id(80),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(95),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(96),wl::JackResource::BOAT},
+			wl::JackMove{wl::map_id(111),wl::JackResource::BOAT}
 		},
 		game_state,
 		history);


### PR DESCRIPTION
## What

Implements functions to find moves of the remaining types: alley moves and boat moves.

### Bugfixes

 - Fixes incorrect iteration past spike nodes, like 3 in the diagram below:

```
			// --( 4 )---( 2^)---( 1 )--    ^: last node
			//             |                *: current node
			//           ( 3*)              therefore should go to 4 next
``` 

## Refreshers

### Refresher on the Nodes

The map is a graph consisting of *Investigator* (i) nodes and *Jack* (j) nodes. Jack must travel through i-nodes until he hits a j-node, but cannot pass through an i-node where an Investigator is currently located.

### Refresher on Blocks

A "Block" is a ring of nodes. You could imagine that the edges between nodes are walls you are holding your hand along the edge walls as you visit nodes in a block:

```
//   (3)------(2)------(1)   // 6, 5, 4, 3, 2, 1 is a block
//    |                 |
//    |          <----  |
//   (4)------(5)------(6)   // 4, 5, 6, 7, 8, 9 is a block
//    | ---->           |
//    |                 |
//   (9)------(8)------(7)
```

### Refresher on Alley Moves

Jack can use an "Alley" tile to move to any other j-node in the same block.

### Refresher on Boat Moves

Some j-nodes are "water" nodes that exist inside a "water block". These special j-nodes can be traversed using a "Boat" tile. Jack can use the tile to move to another water node in the same block
